### PR TITLE
Don't leave timer running during tear-down of widget tree

### DIFF
--- a/lib/src/auto_size_group.dart
+++ b/lib/src/auto_size_group.dart
@@ -27,7 +27,7 @@ class AutoSizeGroup {
 
     if (oldFontSize != _fontSize) {
       _widgetsNotified = false;
-      Timer.run(_notifyListeners);
+      scheduleMicrotask(_notifyListeners);
     }
   }
 


### PR DESCRIPTION
Fixes #34 by using `scheduleMicroTask` rather than `Timer.run`. This ensures that there are no outstanding timers when the widget tree is torn down.