### PR TITLE
Fixes #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ But it does not mean that all `TextSpan`s have at least font size `5`.
 | `textScaleFactor`* | The number of font pixels for each logical pixel. Also affects `minFontSize`, `maxFontSize` and `presetFontSizes`. |
 | `maxLines` | An optional maximum number of lines for the text to span. |
 | `semanticsLabel`* | An alternative semantics label for this text. |
+| `groupScaleFactor` | The factor by which font should be scaled relative to the other elements in the same group. |
 
 Parameters marked with \* behave exactly the same as in `Text`
 

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -31,6 +31,7 @@ class AutoSizeText extends StatefulWidget {
     this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
+    this.groupScaleFactor = 1,
   })  : assert(data != null,
             'A non-null String must be provided to a AutoSizeText widget.'),
         textSpan = null,
@@ -58,6 +59,7 @@ class AutoSizeText extends StatefulWidget {
     this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
+    this.groupScaleFactor = 1,
   })  : assert(textSpan != null,
             'A non-null TextSpan must be provided to a AutoSizeText.rich widget.'),
         data = null,
@@ -216,6 +218,10 @@ class AutoSizeText extends StatefulWidget {
   /// ```
   final String semanticsLabel;
 
+  /// This property scales the text size of this element in the group relative
+  /// to other elements
+  final double groupScaleFactor;
+
   @override
   _AutoSizeTextState createState() => _AutoSizeTextState();
 }
@@ -264,8 +270,9 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       Widget text;
 
       if (widget.group != null) {
-        widget.group._updateFontSize(this, fontSize);
-        text = _buildText(widget.group._fontSize, style, maxLines);
+        widget.group._updateFontSize(this, fontSize / widget.groupScaleFactor);
+        text = _buildText(
+            widget.group._fontSize * widget.groupScaleFactor, style, maxLines);
       } else {
         text = _buildText(fontSize, style, maxLines);
       }


### PR DESCRIPTION
This PR adds a ```groupScaleFactor``` parameter that makes the font scale relative to the rest of the group. While it works perfectly in all my testing, there may be situations where it won't perform as expected.
Not sure if this is the best way to add a PR but GitHub doesn't seem to allow directly linking it to the issue.