### PR TITLE
Clean up ready for null safety

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,5 @@
 include: package:pedantic/analysis_options.yaml
+
 analyzer:
   exclude:
     - "**/*.g.dart"
@@ -10,16 +11,9 @@ analyzer:
     include_file_not_found: ignore
 linter:
   rules:
-    - annotate_overrides
-    - avoid_empty_else
     - avoid_function_literals_in_foreach_calls
-    - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
-    - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
     - avoid_returning_null
-    - avoid_types_as_parameter_names
     - avoid_unused_constructor_parameters
     - await_only_futures
     - camel_case_types
@@ -28,51 +22,24 @@ linter:
     - constant_identifier_names
     - control_flow_in_finally
     - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
     - empty_statements
     - implementation_imports
     - invariant_booleans
     - iterable_contains_unrelated_type
-    - library_names
-    - library_prefixes
     - list_remove_unrelated_type
     - no_adjacent_strings_in_list
-    - no_duplicate_case_values
     - non_constant_identifier_names
-    - null_closures
-    - omit_local_variable_types
     - only_throw_errors
     - overridden_fields
     - package_api_docs
     - package_names
     - package_prefixed_library_names
-    - prefer_adjacent_string_concatenation
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_contains
-    - prefer_equal_for_default_values
-    - prefer_final_fields
     - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_single_quotes
     - prefer_typing_uninitialized_variables
-    - recursive_getters
-    - slash_for_doc_comments
     - test_types_in_equals
     - throw_in_finally
-    - type_init_formals
-    - unawaited_futures
     - unnecessary_brace_in_string_interps
-    - unnecessary_const
     - unnecessary_getters_setters
     - unnecessary_lambdas
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
     - unnecessary_statements
-    - unnecessary_this
-    - unrelated_type_equality_checks
-    - use_rethrow_when_possible
-    - valid_regexps

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,6 +34,7 @@ linter:
     - package_api_docs
     - package_names
     - package_prefixed_library_names
+    - prefer_final_locals
     - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
     - prefer_typing_uninitialized_variables

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,7 @@ analyzer:
     - "**/*.g.dart"
   strong-mode:
     implicit-casts: false
+    implicit-dynamic: false
   errors:
     todo: error
     include_file_not_found: ignore

--- a/demo/lib/animated_input.dart
+++ b/demo/lib/animated_input.dart
@@ -41,7 +41,7 @@ class _AnimatedInputState extends State<AnimatedInput>
     number.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         Future.delayed(Duration(seconds: 3), () {
-          if (mounted) _controller.forward(from: 0.0);
+          if (mounted) _controller.forward(from: 0);
         });
       }
     });

--- a/demo/lib/animated_input.dart
+++ b/demo/lib/animated_input.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-typedef InputBuilder = Function(String input);
+typedef InputBuilder = Widget Function(String input);
 
 class AnimatedInput extends StatefulWidget {
   final String text;
@@ -27,7 +27,7 @@ class _AnimatedInputState extends State<AnimatedInput>
       vsync: this,
     );
 
-    Animation<int> number = IntTween(
+    final number = IntTween(
       begin: 0,
       end: widget.text.length,
     ).animate(_controller);

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -7,7 +7,7 @@ import 'max_lines_demo.dart';
 import 'min_font_size_demo.dart';
 import 'overflow_replacement_demo.dart';
 import 'preset_font_sizes_demo.dart';
-import 'step_granulartity.dart';
+import 'step_granularity.dart';
 import 'sync_demo.dart';
 
 void main() {
@@ -25,7 +25,6 @@ class App extends StatelessWidget {
     SystemChrome.setEnabledSystemUIOverlays([]);
 
     return MaterialApp(
-      debugShowCheckedModeBanner: false,
       theme: ThemeData.light(),
       home: DemoApp(),
     );
@@ -97,7 +96,7 @@ class _DemoAppState extends State<DemoApp> {
       body: Container(
         color: _selectedColor[50],
         child: Padding(
-          padding: EdgeInsets.all(15.0),
+          padding: EdgeInsets.all(15),
           child: _buildDemo(),
         ),
       ),

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -33,6 +33,7 @@ class App extends StatelessWidget {
 }
 
 class DemoApp extends StatefulWidget {
+  @override
   _DemoAppState createState() => _DemoAppState();
 }
 
@@ -86,7 +87,7 @@ class _DemoAppState extends State<DemoApp> {
           ),
         ],
         title: Text(
-          'AutoSizeText: ' + demoNames[_selectedDemo],
+          'AutoSizeText: ${demoNames[_selectedDemo]}',
           style: TextStyle(
             color: _selectedColor[500],
             inherit: true,

--- a/demo/lib/max_lines_demo.dart
+++ b/demo/lib/max_lines_demo.dart
@@ -23,27 +23,27 @@ class MaxlinesDemo extends StatelessWidget {
                 child: !richText
                     ? Text(
                         input,
-                        style: TextStyle(fontSize: 30.0),
+                        style: TextStyle(fontSize: 30),
                       )
                     : Text.rich(
                         spanFromString(input),
-                        style: TextStyle(fontSize: 30.0),
+                        style: TextStyle(fontSize: 30),
                       ),
               ),
             ),
-            SizedBox(width: 10.0),
+            SizedBox(width: 10),
             Expanded(
               child: TextCard(
                 title: 'AutoSizeText',
                 child: !richText
                     ? AutoSizeText(
                         input,
-                        style: TextStyle(fontSize: 30.0),
+                        style: TextStyle(fontSize: 30),
                         maxLines: 2,
                       )
                     : AutoSizeText.rich(
                         spanFromString(input),
-                        style: TextStyle(fontSize: 30.0),
+                        style: TextStyle(fontSize: 30),
                         maxLines: 2,
                       ),
               ),

--- a/demo/lib/min_font_size_demo.dart
+++ b/demo/lib/min_font_size_demo.dart
@@ -13,8 +13,10 @@ class MinFontSizeDemo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AnimatedInput(
-      text:
-          "This String's size will not be smaller than 20. It will be automatically resized to fit on 4 lines. Otherwise, the String will be ellipsized. Here is some random stuff, just to make sure it is long enough.",
+      text: 'This String\'s size will not be smaller than 20. It will be '
+          'automatically resized to fit on 4 lines. Otherwise, the String will '
+          'be ellipsized. Here is some random stuff, just to make sure it is '
+          'long enough.',
       builder: (input) {
         return Row(
           children: <Widget>[
@@ -24,32 +26,32 @@ class MinFontSizeDemo extends StatelessWidget {
                 child: !richText
                     ? Text(
                         input,
-                        style: TextStyle(fontSize: 30.0),
+                        style: TextStyle(fontSize: 30),
                         maxLines: 4,
                       )
                     : Text.rich(
                         spanFromString(input),
-                        style: TextStyle(fontSize: 30.0),
+                        style: TextStyle(fontSize: 30),
                         maxLines: 4,
                       ),
               ),
             ),
-            SizedBox(width: 10.0),
+            SizedBox(width: 10),
             Expanded(
               child: TextCard(
                 title: 'AutoSizeText',
                 child: !richText
                     ? AutoSizeText(
                         input,
-                        style: TextStyle(fontSize: 30.0),
-                        minFontSize: 20.0,
+                        style: TextStyle(fontSize: 30),
+                        minFontSize: 20,
                         overflow: TextOverflow.ellipsis,
                         maxLines: 4,
                       )
                     : AutoSizeText.rich(
                         spanFromString(input),
-                        style: TextStyle(fontSize: 30.0),
-                        minFontSize: 20.0,
+                        style: TextStyle(fontSize: 30),
+                        minFontSize: 20,
                         overflow: TextOverflow.ellipsis,
                         maxLines: 4,
                       ),

--- a/demo/lib/overflow_replacement_demo.dart
+++ b/demo/lib/overflow_replacement_demo.dart
@@ -13,8 +13,10 @@ class OverflowReplacementDemo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AnimatedInput(
-      text:
-          "This String's size will not be smaller than 20. It will be automatically resized to fit on 4 lines. Otherwise, it will be replaced by a replacement String! Here is some random stuff, just to make sure it is long enough.",
+      text: 'This String\'s size will not be smaller than 20. It will be '
+          'automatically resized to fit on 4 lines. Otherwise, it will be '
+          'replaced by a replacement String! Here is some random stuff, just '
+          'to make sure it is long enough.',
       builder: (input) {
         return Row(
           children: <Widget>[

--- a/demo/lib/preset_font_sizes_demo.dart
+++ b/demo/lib/preset_font_sizes_demo.dart
@@ -13,8 +13,9 @@ class PresetFontSizesDemo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AnimatedInput(
-      text:
-          'This String has only three allowed sizes: 40, 20 and 14. It will be automatically resized to fit on 4 lines. With this setting, you have the most control.',
+      text: 'This String has only three allowed sizes: 40, 20 and 14. It will '
+          'be automatically resized to fit on 4 lines. With this setting, you '
+          'have the most control.',
       builder: (input) {
         return Row(
           children: <Widget>[
@@ -24,29 +25,29 @@ class PresetFontSizesDemo extends StatelessWidget {
                 child: !richText
                     ? Text(
                         input,
-                        style: TextStyle(fontSize: 40.0),
+                        style: TextStyle(fontSize: 40),
                         maxLines: 4,
                       )
                     : Text.rich(
                         spanFromString(input),
-                        style: TextStyle(fontSize: 40.0),
+                        style: TextStyle(fontSize: 40),
                         maxLines: 4,
                       ),
               ),
             ),
-            SizedBox(width: 10.0),
+            SizedBox(width: 10),
             Expanded(
               child: TextCard(
                 title: 'AutoSizeText',
                 child: !richText
                     ? AutoSizeText(
                         input,
-                        presetFontSizes: [40.0, 20.0, 14.0],
+                        presetFontSizes: [40, 20, 14],
                         maxLines: 4,
                       )
                     : AutoSizeText.rich(
                         spanFromString(input),
-                        presetFontSizes: [40.0, 20.0, 14.0],
+                        presetFontSizes: [40, 20, 14],
                         maxLines: 4,
                       ),
               ),

--- a/demo/lib/step_granularity.dart
+++ b/demo/lib/step_granularity.dart
@@ -14,7 +14,9 @@ class StepGranularityDemo extends StatelessWidget {
   Widget build(BuildContext context) {
     return AnimatedInput(
       text:
-          "This String changes its size with a stepGranularity of 10. It will be automatically resized to fit on 4 lines. Now the text is so small, you can't even read it...",
+          'This String changes its size with a stepGranularity of 10. It will '
+          'be automatically resized to fit on 4 lines. Now the text is so '
+          'small, you can\'t even read it...',
       builder: (input) {
         return Row(
           children: <Widget>[
@@ -24,34 +26,34 @@ class StepGranularityDemo extends StatelessWidget {
                 child: !richText
                     ? Text(
                         input,
-                        style: TextStyle(fontSize: 40.0),
+                        style: TextStyle(fontSize: 40),
                         maxLines: 4,
                       )
                     : Text.rich(
                         spanFromString(input),
-                        style: TextStyle(fontSize: 40.0),
+                        style: TextStyle(fontSize: 40),
                         maxLines: 4,
                       ),
               ),
             ),
-            SizedBox(width: 10.0),
+            SizedBox(width: 10),
             Expanded(
               child: TextCard(
                 title: 'AutoSizeText',
                 child: !richText
                     ? AutoSizeText(
                         input,
-                        style: TextStyle(fontSize: 40.0),
-                        stepGranularity: 10.0,
-                        minFontSize: 10.0,
+                        style: TextStyle(fontSize: 40),
+                        stepGranularity: 10,
+                        minFontSize: 10,
                         overflow: TextOverflow.ellipsis,
                         maxLines: 4,
                       )
                     : AutoSizeText.rich(
                         spanFromString(input),
-                        style: TextStyle(fontSize: 40.0),
-                        stepGranularity: 10.0,
-                        minFontSize: 10.0,
+                        style: TextStyle(fontSize: 40),
+                        stepGranularity: 10,
+                        minFontSize: 10,
                         overflow: TextOverflow.ellipsis,
                         maxLines: 4,
                       ),

--- a/demo/lib/sync_demo.dart
+++ b/demo/lib/sync_demo.dart
@@ -9,6 +9,7 @@ class SyncDemo extends StatefulWidget {
 
   SyncDemo(this.richText);
 
+  @override
   _SyncDemoState createState() => _SyncDemoState();
 }
 

--- a/demo/lib/sync_demo.dart
+++ b/demo/lib/sync_demo.dart
@@ -54,7 +54,8 @@ class _SyncDemoState extends State<SyncDemo>
   Widget build(BuildContext context) {
     var group = AutoSizeGroup();
     var text =
-        'These AutoSizeTexts fit the available space and synchronize their text sizes.';
+        'These AutoSizeTexts fit the available space and synchronize their '
+        'text sizes.';
     return Column(
       children: <Widget>[
         Expanded(
@@ -65,14 +66,14 @@ class _SyncDemoState extends State<SyncDemo>
               child: AutoSizeText(
                 text,
                 group: group,
-                style: TextStyle(fontSize: 40.0),
+                style: TextStyle(fontSize: 40),
                 stepGranularity: 0.1,
                 maxLines: 3,
               ),
               replacement: AutoSizeText.rich(
                 spanFromString(text),
                 group: group,
-                style: TextStyle(fontSize: 40.0),
+                style: TextStyle(fontSize: 40),
                 stepGranularity: 0.1,
                 maxLines: 4,
               ),
@@ -96,14 +97,14 @@ class _SyncDemoState extends State<SyncDemo>
                     child: AutoSizeText(
                       text,
                       group: group,
-                      style: TextStyle(fontSize: 40.0),
+                      style: TextStyle(fontSize: 40),
                       stepGranularity: 0.1,
                       maxLines: 3,
                     ),
                     replacement: AutoSizeText.rich(
                       spanFromString(text),
                       group: group,
-                      style: TextStyle(fontSize: 40.0),
+                      style: TextStyle(fontSize: 40),
                       stepGranularity: 0.1,
                       maxLines: 4,
                     ),

--- a/demo/lib/text_card.dart
+++ b/demo/lib/text_card.dart
@@ -15,16 +15,16 @@ class TextCard extends StatelessWidget {
         Expanded(
           child: Card(
             child: Padding(
-              padding: const EdgeInsets.all(8.0),
+              padding: const EdgeInsets.all(8),
               child: child,
             ),
-            elevation: 0.0,
+            elevation: 0,
             clipBehavior: Clip.antiAlias,
             color: Colors.transparent,
             shape: RoundedRectangleBorder(
               side: BorderSide(color: Colors.grey, width: 1.5),
               borderRadius: BorderRadius.all(
-                Radius.circular(10.0),
+                Radius.circular(10),
               ),
             ),
           ),

--- a/demo/lib/utils.dart
+++ b/demo/lib/utils.dart
@@ -2,12 +2,12 @@ import 'package:flutter/widgets.dart';
 
 TextSpan spanFromString(String text) {
   var index = 0;
-  var styles = [
-    TextStyle(fontSize: 30.0),
-    TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold),
-    TextStyle(fontSize: 40.0, fontStyle: FontStyle.italic),
+  final styles = [
+    TextStyle(fontSize: 30),
+    TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+    TextStyle(fontSize: 40, fontStyle: FontStyle.italic),
   ];
-  var spans = text.split(' ').map((word) {
+  final spans = text.split(' ').map((word) {
     if (index == 3) index = 0;
     return TextSpan(
       style: styles[index++],

--- a/demo/lib/utils.dart
+++ b/demo/lib/utils.dart
@@ -11,7 +11,7 @@ TextSpan spanFromString(String text) {
     if (index == 3) index = 0;
     return TextSpan(
       style: styles[index++],
-      text: word + ' ',
+      text: '$word ',
     );
   }).toList();
 

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -1,10 +1,10 @@
 name: demo
 description: AutoSizeText Demo App
 
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
-  sdk: ">=2.1.0 <3.0.0" 
+  sdk: ">=2.10.0 <3.0.0" 
 
 dependencies:
   flutter:
@@ -13,8 +13,8 @@ dependencies:
   auto_size_text:
     path: ../
 
-  bottom_navy_bar: ^4.2.0
-  material_design_icons_flutter: ^3.2.3695
+  bottom_navy_bar: ^5.6.0
+  material_design_icons_flutter: ^4.0.5755
 
 dev_dependencies:
   flutter_test: 
@@ -22,3 +22,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+publish_to: none

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   auto_size_text:
     path: ../
 
-  bottom_navy_bar: ^5.6.0
+  bottom_navy_bar: ^4.2.0
   material_design_icons_flutter: ^4.0.5755
 
 dev_dependencies:

--- a/example/main.dart
+++ b/example/main.dart
@@ -12,11 +12,11 @@ class App extends StatelessWidget {
       home: Scaffold(
         body: Center(
           child: SizedBox(
-            width: 200.0,
-            height: 140.0,
+            width: 200,
+            height: 140,
             child: AutoSizeText(
               'This string will be automatically resized to fit in two lines.',
-              style: TextStyle(fontSize: 30.0),
+              style: TextStyle(fontSize: 30),
               maxLines: 2,
             ),
           ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: AutoSizeText Example
 version: 1.0.0
 
 environment:
-sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -19,3 +19,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true 
+
+publish_to: none

--- a/lib/auto_size_text.dart
+++ b/lib/auto_size_text.dart
@@ -1,4 +1,5 @@
-/// Flutter widget that automatically resizes text to fit perfectly within its bounds.
+/// Flutter widget that automatically resizes text to fit perfectly within its
+/// bounds.
 library auto_size_text;
 
 import 'dart:async';

--- a/lib/src/auto_size_group.dart
+++ b/lib/src/auto_size_group.dart
@@ -6,11 +6,11 @@ class AutoSizeGroup {
   var _widgetsNotified = false;
   double _fontSize = double.infinity;
 
-  _register(_AutoSizeTextState text) {
+  void _register(_AutoSizeTextState text) {
     _listeners[text] = double.infinity;
   }
 
-  _updateFontSize(_AutoSizeTextState text, double maxFontSize) {
+  void _updateFontSize(_AutoSizeTextState text, double maxFontSize) {
     var oldFontSize = _fontSize;
     if (maxFontSize <= _fontSize) {
       _fontSize = maxFontSize;
@@ -31,7 +31,7 @@ class AutoSizeGroup {
     }
   }
 
-  _notifyListeners() {
+  void _notifyListeners() {
     if (_widgetsNotified) {
       return;
     } else {
@@ -45,7 +45,7 @@ class AutoSizeGroup {
     }
   }
 
-  _remove(_AutoSizeTextState text) {
+  void _remove(_AutoSizeTextState text) {
     _updateFontSize(text, double.infinity);
     _listeners.remove(text);
   }

--- a/lib/src/auto_size_group.dart
+++ b/lib/src/auto_size_group.dart
@@ -18,7 +18,7 @@ class AutoSizeGroup {
     } else if (_listeners[text] == _fontSize) {
       _listeners[text] = maxFontSize;
       _fontSize = double.infinity;
-      for (var size in _listeners.values) {
+      for (final size in _listeners.values) {
         if (size < _fontSize) _fontSize = size;
       }
     } else {

--- a/lib/src/auto_size_group.dart
+++ b/lib/src/auto_size_group.dart
@@ -4,14 +4,14 @@ part of auto_size_text;
 class AutoSizeGroup {
   final _listeners = <_AutoSizeTextState, double>{};
   var _widgetsNotified = false;
-  double _fontSize = double.infinity;
+  var _fontSize = double.infinity;
 
   void _register(_AutoSizeTextState text) {
     _listeners[text] = double.infinity;
   }
 
   void _updateFontSize(_AutoSizeTextState text, double maxFontSize) {
-    var oldFontSize = _fontSize;
+    final oldFontSize = _fontSize;
     if (maxFontSize <= _fontSize) {
       _fontSize = maxFontSize;
       _listeners[text] = maxFontSize;
@@ -38,7 +38,7 @@ class AutoSizeGroup {
       _widgetsNotified = true;
     }
 
-    for (var textState in _listeners.keys) {
+    for (final textState in _listeners.keys) {
       if (textState.mounted) {
         textState._notifySync();
       }

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -281,31 +281,31 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
   void _validateProperties(TextStyle style, int maxLines) {
     assert(widget.overflow == null || widget.overflowReplacement == null,
-        'Either overflow or overflowReplacement have to be null.');
+        'Either overflow or overflowReplacement must be null.');
     assert(maxLines == null || maxLines > 0,
-        'MaxLines has to be grater than or equal to 1.');
+        'MaxLines must be greater than or equal to 1.');
     assert(widget.key == null || widget.key != widget.textKey,
-        'Key and textKey cannot be the same.');
+        'Key and textKey must not be equal.');
 
     if (widget.presetFontSizes == null) {
       assert(
           widget.stepGranularity >= 0.1,
-          'StepGranularity has to be greater than or equal to 0.1. It is not a '
+          'StepGranularity must be greater than or equal to 0.1. It is not a '
           'good idea to resize the font with a higher accuracy.');
       assert(widget.minFontSize >= 0,
-          'MinFontSize has to be greater than or equal to 0.');
+          'MinFontSize must be greater than or equal to 0.');
       assert(widget.maxFontSize > 0, 'MaxFontSize has to be greater than 0.');
       assert(widget.minFontSize <= widget.maxFontSize,
-          'MinFontSize has to be smaller or equal than maxFontSize.');
+          'MinFontSize must be smaller or equal than maxFontSize.');
       assert(widget.minFontSize / widget.stepGranularity % 1 == 0,
-          'MinFontSize has to be multiples of stepGranularity.');
+          'MinFontSize must be a multiple of stepGranularity.');
       if (widget.maxFontSize != double.infinity) {
         assert(widget.maxFontSize / widget.stepGranularity % 1 == 0,
-            'MaxFontSize has to be multiples of stepGranularity.');
+            'MaxFontSize must be a multiple of stepGranularity.');
       }
     } else {
       assert(widget.presetFontSizes.isNotEmpty,
-          'PresetFontSizes has to be nonempty.');
+          'PresetFontSizes must not be empty.');
     }
   }
 

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -1,6 +1,7 @@
 part of auto_size_text;
 
-/// Flutter widget that automatically resizes text to fit perfectly within its bounds.
+/// Flutter widget that automatically resizes text to fit perfectly within its
+/// bounds.
 ///
 /// All size constraints as well as maxLines are taken into account. If the text
 /// overflows anyway, you should check if the parent widget actually constraints
@@ -86,16 +87,16 @@ class AutoSizeText extends StatefulWidget {
   final TextStyle style;
 
   // The default font size if none is specified.
-  static const double _defaultFontSize = 14.0;
+  static const double _defaultFontSize = 14;
 
   /// The strut style to use. Strut style defines the strut, which sets minimum
   /// vertical layout metrics.
   ///
   /// Omitting or providing null will disable strut.
   ///
-  /// Omitting or providing null for any properties of [StrutStyle] will result in
-  /// default values being used. It is highly recommended to at least specify a
-  /// font size.
+  /// Omitting or providing null for any properties of [StrutStyle] will result
+  /// in default values being used. It is highly recommended to at least specify
+  /// a font size.
   ///
   /// See [StrutStyle] for details.
   final StrutStyle strutStyle;
@@ -243,7 +244,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, size) {
-      var defaultTextStyle = DefaultTextStyle.of(context);
+      final defaultTextStyle = DefaultTextStyle.of(context);
 
       var style = widget.style;
       if (widget.style == null || widget.style.inherit) {
@@ -253,13 +254,13 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         style = style.copyWith(fontSize: AutoSizeText._defaultFontSize);
       }
 
-      var maxLines = widget.maxLines ?? defaultTextStyle.maxLines;
+      final maxLines = widget.maxLines ?? defaultTextStyle.maxLines;
 
       _sanityCheck(style, maxLines);
 
-      var result = _calculateFontSize(size, style, maxLines);
-      var fontSize = result[0] as double;
-      var textFits = result[1] as bool;
+      final result = _calculateFontSize(size, style, maxLines);
+      final fontSize = result[0] as double;
+      final textFits = result[1] as bool;
 
       Widget text;
 
@@ -287,8 +288,10 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         'Key and textKey cannot be the same.');
 
     if (widget.presetFontSizes == null) {
-      assert(widget.stepGranularity >= 0.1,
-          'StepGranularity has to be greater than or equal to 0.1. It is not a good idea to resize the font with a higher accuracy.');
+      assert(
+          widget.stepGranularity >= 0.1,
+          'StepGranularity has to be greater than or equal to 0.1. It is not a '
+          'good idea to resize the font with a higher accuracy.');
       assert(widget.minFontSize >= 0,
           'MinFontSize has to be greater than or equal to 0.');
       assert(widget.maxFontSize > 0, 'MaxFontSize has to be greater than 0.');
@@ -307,24 +310,24 @@ class _AutoSizeTextState extends State<AutoSizeText> {
   }
 
   List _calculateFontSize(BoxConstraints size, TextStyle style, int maxLines) {
-    var span = TextSpan(
+    final span = TextSpan(
       style: widget.textSpan?.style ?? style,
       text: widget.textSpan?.text ?? widget.data,
       children: widget.textSpan?.children,
       recognizer: widget.textSpan?.recognizer,
     );
 
-    var userScale =
+    final userScale =
         widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context);
 
     int left;
     int right;
 
-    var presetFontSizes = widget.presetFontSizes?.reversed?.toList();
+    final presetFontSizes = widget.presetFontSizes?.reversed?.toList();
     if (presetFontSizes == null) {
-      var defaultFontSize =
+      final defaultFontSize =
           style.fontSize.clamp(widget.minFontSize, widget.maxFontSize);
-      var defaultScale = defaultFontSize * userScale / style.fontSize;
+      final defaultScale = defaultFontSize * userScale / style.fontSize;
       if (_checkTextFits(span, defaultScale, maxLines, size)) {
         return [defaultFontSize * userScale, true];
       }
@@ -338,7 +341,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
     var lastValueFits = false;
     while (left <= right) {
-      var mid = (left + (right - left) / 2).toInt();
+      final mid = (left + (right - left) / 2).toInt();
       double scale;
       if (presetFontSizes == null) {
         scale = mid * userScale * widget.stepGranularity / style.fontSize;
@@ -370,9 +373,9 @@ class _AutoSizeTextState extends State<AutoSizeText> {
   bool _checkTextFits(
       TextSpan text, double scale, int maxLines, BoxConstraints constraints) {
     if (!widget.wrapWords) {
-      var words = text.toPlainText().split(RegExp('\\s+'));
+      final words = text.toPlainText().split(RegExp('\\s+'));
 
-      var wordWrapTp = TextPainter(
+      final wordWrapTp = TextPainter(
         text: TextSpan(
           style: text.style,
           text: words.join('\n'),
@@ -393,7 +396,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       }
     }
 
-    var tp = TextPainter(
+    final tp = TextPainter(
       text: text,
       textAlign: widget.textAlign ?? TextAlign.left,
       textDirection: widget.textDirection ?? TextDirection.ltr,

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -172,6 +172,8 @@ class AutoSizeText extends StatefulWidget {
   final bool wrapWords;
 
   /// How visual overflow should be handled.
+  ///
+  /// Defaults to retrieving the value from the nearest [DefaultTextStyle] ancestor.
   final TextOverflow overflow;
 
   /// If the text is overflowing and does not fit its bounds, this widget is
@@ -341,7 +343,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
     var lastValueFits = false;
     while (left <= right) {
-      final mid = (left + (right - left) / 2).toInt();
+      final mid = (left + (right - left) / 2).floor();
       double scale;
       if (presetFontSizes == null) {
         scale = mid * userScale * widget.stepGranularity / style.fontSize;
@@ -375,7 +377,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
     if (!widget.wrapWords) {
       final words = text.toPlainText().split(RegExp('\\s+'));
 
-      final wordWrapTp = TextPainter(
+      final wordWrapTextPainter = TextPainter(
         text: TextSpan(
           style: text.style,
           text: words.join('\n'),
@@ -388,15 +390,15 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         strutStyle: widget.strutStyle,
       );
 
-      wordWrapTp.layout(maxWidth: constraints.maxWidth);
+      wordWrapTextPainter.layout(maxWidth: constraints.maxWidth);
 
-      if (wordWrapTp.didExceedMaxLines ||
-          wordWrapTp.width > constraints.maxWidth) {
+      if (wordWrapTextPainter.didExceedMaxLines ||
+          wordWrapTextPainter.width > constraints.maxWidth) {
         return false;
       }
     }
 
-    final tp = TextPainter(
+    final textPainter = TextPainter(
       text: text,
       textAlign: widget.textAlign ?? TextAlign.left,
       textDirection: widget.textDirection ?? TextDirection.ltr,
@@ -406,11 +408,11 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       strutStyle: widget.strutStyle,
     );
 
-    tp.layout(maxWidth: constraints.maxWidth);
+    textPainter.layout(maxWidth: constraints.maxWidth);
 
-    return !(tp.didExceedMaxLines ||
-        tp.height > constraints.maxHeight ||
-        tp.width > constraints.maxWidth);
+    return !(textPainter.didExceedMaxLines ||
+        textPainter.height > constraints.maxHeight ||
+        textPainter.width > constraints.maxWidth);
   }
 
   Widget _buildText(double fontSize, TextStyle style, int maxLines) {

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -329,7 +329,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
           style.fontSize.clamp(widget.minFontSize, widget.maxFontSize);
       final defaultScale = defaultFontSize * userScale / style.fontSize;
       if (_checkTextFits(span, defaultScale, maxLines, size)) {
-        return [defaultFontSize * userScale, true];
+        return <Object>[defaultFontSize * userScale, true];
       }
 
       left = (widget.minFontSize / widget.stepGranularity).floor();
@@ -367,7 +367,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       fontSize = presetFontSizes[right] * userScale;
     }
 
-    return [fontSize, lastValueFits];
+    return <Object>[fontSize, lastValueFits];
   }
 
   bool _checkTextFits(

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -222,7 +222,7 @@ class AutoSizeText extends StatefulWidget {
 
 class _AutoSizeTextState extends State<AutoSizeText> {
   @override
-  initState() {
+  void initState() {
     super.initState();
 
     if (widget.group != null) {

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -81,7 +81,7 @@ class AutoSizeText extends StatefulWidget {
 
   /// If non-null, the style to use for this text.
   ///
-  /// If the style's 'inherit' property is true, the style will be merged with
+  /// If the style's "inherit" property is true, the style will be merged with
   /// the closest enclosing [DefaultTextStyle]. Otherwise, the style will
   /// replace the closest enclosing [DefaultTextStyle].
   final TextStyle style;
@@ -213,7 +213,7 @@ class AutoSizeText extends StatefulWidget {
   /// text value:
   ///
   /// ```dart
-  /// Text(r'$$', semanticsLabel: 'Double dollars')
+  /// AutoSizeText(r'$$', semanticsLabel: 'Double dollars')
   /// ```
   final String semanticsLabel;
 
@@ -256,7 +256,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
       final maxLines = widget.maxLines ?? defaultTextStyle.maxLines;
 
-      _sanityCheck(style, maxLines);
+      _validateProperties(style, maxLines);
 
       final result = _calculateFontSize(size, style, maxLines);
       final fontSize = result[0] as double;
@@ -279,7 +279,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
     });
   }
 
-  void _sanityCheck(TextStyle style, int maxLines) {
+  void _validateProperties(TextStyle style, int maxLines) {
     assert(widget.overflow == null || widget.overflowReplacement == null,
         'Either overflow or overflowReplacement have to be null.');
     assert(maxLines == null || maxLines > 0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: auto_size_text
 description: Flutter widget that automatically resizes text to fit perfectly within its bounds.
-version: 2.1.0
+version: 2.1.1
 author: Simon Leier <simonleier@gmail.com>
 homepage: https://github.com/leisim/auto_size_text
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -14,4 +14,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: '>=1.4.0 <3.0.0'
+  pedantic: '>=1.9.0 <3.0.0'

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -51,7 +51,7 @@ void main() {
 
   testWidgets('Respects inherit style', (tester) async {
     var defaultStyle = TextStyle(
-      fontSize: 20.0,
+      fontSize: 20,
       color: Colors.yellow,
     );
     var text = await pumpAndGetText(

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -50,11 +50,11 @@ void main() {
   });
 
   testWidgets('Respects inherit style', (tester) async {
-    var defaultStyle = TextStyle(
+    final defaultStyle = TextStyle(
       fontSize: 20,
       color: Colors.yellow,
     );
-    var text = await pumpAndGetText(
+    final text = await pumpAndGetText(
       tester: tester,
       widget: DefaultTextStyle(
         style: defaultStyle,
@@ -69,7 +69,7 @@ void main() {
     );
     expect(text.style, defaultStyle);
 
-    var richText = getRichText(tester);
+    final richText = getRichText(tester);
     expect(richText.textAlign, TextAlign.right);
     expect(richText.softWrap, false);
     expect(richText.overflow, TextOverflow.ellipsis);
@@ -90,8 +90,8 @@ void main() {
   });
 
   testWidgets('Uses textKey', (tester) async {
-    var textKey = GlobalKey();
-    var text = await pumpAndGetText(
+    final textKey = GlobalKey();
+    final text = await pumpAndGetText(
       tester: tester,
       widget: AutoSizeText(
         'A text with key',

--- a/test/group_test.dart
+++ b/test/group_test.dart
@@ -52,8 +52,8 @@ class GroupTestState extends State<GroupTest> {
 }
 
 void _expectFontSizes(WidgetTester tester, double fontSize) {
-  var texts = tester.widgetList(find.byType(Text));
-  for (var text in texts) {
+  final texts = tester.widgetList(find.byType(Text));
+  for (final text in texts) {
     expect(effectiveFontSize(text as Text), fontSize);
   }
 }
@@ -64,7 +64,7 @@ void main() {
 
     _expectFontSizes(tester, 50);
 
-    var state = tester.state(find.byType(GroupTest)) as GroupTestState;
+    final state = tester.state(find.byType(GroupTest)) as GroupTestState;
 
     state.width1 = 200;
     state.refresh();

--- a/test/group_test.dart
+++ b/test/group_test.dart
@@ -51,7 +51,7 @@ class GroupTestState extends State<GroupTest> {
   }
 }
 
-_expectFontSizes(WidgetTester tester, double fontSize) {
+void _expectFontSizes(WidgetTester tester, double fontSize) {
   var texts = tester.widgetList(find.byType(Text));
   for (var text in texts) {
     expect(effectiveFontSize(text as Text), fontSize);
@@ -109,8 +109,6 @@ void main() {
     await tester.pump(Duration.zero);
     _expectFontSizes(tester, 50);
 
-    //TODO remove when flutter bug is fixed https://github.com/flutter/flutter/issues/24166
-    await tester.pumpWidget(Container());
     await tester.pump(Duration.zero);
   });
 }

--- a/test/overflow_replacement_test.dart
+++ b/test/overflow_replacement_test.dart
@@ -6,7 +6,7 @@ import 'utils.dart';
 
 void main() {
   testWidgets('Overflow replacement visible on overflow', (tester) async {
-    var text = await pumpAndGetText(
+    final text = await pumpAndGetText(
       tester: tester,
       widget: SizedBox(
         width: 100,
@@ -23,7 +23,7 @@ void main() {
 
   testWidgets('Overflow replacement not visible without overflow',
       (tester) async {
-    var text = await pumpAndGetText(
+    final text = await pumpAndGetText(
       tester: tester,
       widget: SizedBox(
         width: 100,

--- a/test/text_fits_test.dart
+++ b/test/text_fits_test.dart
@@ -61,10 +61,9 @@ void main() {
   });
 
   testWidgets('Text fits height', (tester) async {
-    // TODO uncomment when flutter bug is fixed (https://github.com/flutter/flutter/issues/22557)
-    /*await pumpAndExpectFontSize(
+    await pumpAndExpectFontSize(
       tester: tester,
-      fontSize: 30,
+      expectedFontSize: 30,
       widget: SizedBox(
         height: 30,
         child: AutoSizeText(
@@ -73,7 +72,7 @@ void main() {
           maxLines: 1,
         ),
       ),
-    );*/
+    );
 
     await pumpAndExpectFontSize(
       tester: tester,

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -5,11 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-double effectiveFontSize(Text text) {
-  return (text.textScaleFactor ?? 1) * text.style.fontSize;
-}
+double effectiveFontSize(Text text) =>
+    (text.textScaleFactor ?? 1) * text.style.fontSize;
 
-bool testIfTextFits(
+bool doesTextFit(
   Text text, [
   double maxWidth = double.infinity,
   double maxHeight = double.infinity,
@@ -22,7 +21,7 @@ bool testIfTextFits(
     maxLines = maxLines.clamp(1, wordCount) as int;
   }
 
-  final tp = TextPainter(
+  final textPainter = TextPainter(
     text: span,
     textAlign: text.textAlign,
     textDirection: text.textDirection,
@@ -32,11 +31,11 @@ bool testIfTextFits(
     strutStyle: text.strutStyle,
   );
 
-  tp.layout(maxWidth: maxWidth);
+  textPainter.layout(maxWidth: maxWidth);
 
-  return !(tp.didExceedMaxLines ||
-      tp.height > maxHeight ||
-      tp.width > maxWidth);
+  return !(textPainter.didExceedMaxLines ||
+      textPainter.height > maxHeight ||
+      textPainter.width > maxWidth);
 }
 
 bool prepared = false;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -15,14 +15,14 @@ bool testIfTextFits(
   double maxHeight = double.infinity,
   bool wrapWords = true,
 ]) {
-  var span = text.textSpan ?? TextSpan(text: text.data, style: text.style);
+  final span = text.textSpan ?? TextSpan(text: text.data, style: text.style);
   var maxLines = text.maxLines;
   if (!wrapWords) {
-    var wordCount = span.toPlainText().split(RegExp('\\s+')).length;
+    final wordCount = span.toPlainText().split(RegExp('\\s+')).length;
     maxLines = maxLines.clamp(1, wordCount) as int;
   }
 
-  var tp = TextPainter(
+  final tp = TextPainter(
     text: span,
     textAlign: text.textAlign,
     textDirection: text.textDirection,
@@ -83,13 +83,12 @@ Future pumpAndExpectFontSize({
   @required double expectedFontSize,
   @required Widget widget,
 }) async {
-  var text = await pumpAndGetText(tester: tester, widget: widget);
+  final text = await pumpAndGetText(tester: tester, widget: widget);
   expect(effectiveFontSize(text), expectedFontSize);
 }
 
-RichText getRichText(WidgetTester tester) {
-  return tester.widget(find.byType(RichText));
-}
+RichText getRichText(WidgetTester tester) =>
+    tester.widget(find.byType(RichText));
 
 class OverflowNotifier extends StatelessWidget {
   final VoidCallback overflowCallback;

--- a/test/wrap_words_test.dart
+++ b/test/wrap_words_test.dart
@@ -52,7 +52,7 @@ void main() {
         ),
       ),
     );
-    var height = tester.getSize(find.byType(RichText)).height;
+    final height = tester.getSize(find.byType(RichText)).height;
     expect(height, 60);
   });
 }


### PR DESCRIPTION
This PR cleans up the codebase a little:

- Upgrades to a newer version of pedantic, removes redundant rules, and fixes newly-added lints
- Uses `final` where possible for performance
- Fixes filename spelling nit (granulartity -> granularity)
- Uncomments out test now that bug has been fixed, and remove unnecessary test pump
- Takes advantage of Dart int-to-double inference for fonts and pixel padding

Assuming you're happy to merge this pull request, I have a second one that builds on it and adds support for sound null safety:
https://github.com/timsneath/auto_size_text/pull/1