### PR TITLE
Add an optional wrapTextWidget property

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ AutoSizeText(
 
 ### stepGranularity
 
-The `AutoSizeText` will try each font size, starting with `TextStyle.fontSize` until the text fits within its bounds.  
+The `AutoSizeText` will try each font size, starting with `TextStyle.fontSize` until the text fits within its bounds.
 `stepGranularity` specifies how much the font size is decreased each step. Usually, this value should not be below `1` for best performance.
 
 ```dart
@@ -166,7 +166,7 @@ You can also use Rich Text (like different text styles or links) with `AutoSizeT
 (which works exactly like the `Text.rich()` constructor).
 
 The only thing you have to be aware of is how the font size calculation works: The `fontSize` in the `style`
-parameter of `AutoSizeText` (or the inherited `fontSize` if none is set) is used as reference.  
+parameter of `AutoSizeText` (or the inherited `fontSize` if none is set) is used as reference.
 
 For example:
 ```dart
@@ -176,7 +176,7 @@ AutoSizeText.rich(
   minFontSize: 5,
 )
 ```
-The text will be at least 1/4 of its original size (5 / 20 = 1/4).  
+The text will be at least 1/4 of its original size (5 / 20 = 1/4).
 But it does not mean that all `TextSpan`s have at least font size `5`.
 
 ![](https://raw.githubusercontent.com/leisim/auto_size_text/master/.github/art/maxlines_rich.gif)
@@ -191,6 +191,7 @@ But it does not mean that all `TextSpan`s have at least font size `5`.
 | `style`* | If non-null, the style to use for this text |
 | `minFontSize` | The **minimum** text size constraint to be used when auto-sizing text. <br>*Is being ignored if `presetFontSizes` is set.*  |
 | `maxFontSize` | The **maximum** text size constraint to be used when auto-sizing text. <br>*Is being ignored if `presetFontSizes` is set.* |
+| `wrapTextWidget` | Wrap the text by a Widget of your choice. For example wrap the text by a `Container` with some custom padding. |
 | `stepGranularity` | The step size in which the font size is being adapted to constraints. |
 | `presetFontSizes` | Predefines all the possible font sizes.<br> **Important:** `presetFontSizes` have to be in descending order.  |
 | `group` | Synchronizes the size of multiple `AutoSizeText`s |
@@ -233,7 +234,7 @@ Row(
   ],
 )
 ```
-Because `Row` and other widgets like `Container`, `Column` or `ListView` do not constrain their children, the text will overflow.  
+Because `Row` and other widgets like `Container`, `Column` or `ListView` do not constrain their children, the text will overflow.
 You can fix this by constraining the `AutoSizeText`. Wrap it with `Expanded` in case of `Row` and `Column` or use a `SizedBox` or another widget with fixed width (and height).
 
 **Correct** code:

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -32,6 +32,7 @@ class AutoSizeText extends StatefulWidget {
     this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
+    this.wrapTextWidget,
   })  : textSpan = null,
         super(key: key);
 
@@ -57,6 +58,7 @@ class AutoSizeText extends StatefulWidget {
     this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
+    this.wrapTextWidget,
   })  : data = null,
         super(key: key);
 
@@ -215,6 +217,12 @@ class AutoSizeText extends StatefulWidget {
   /// ```
   final String? semanticsLabel;
 
+  /// Specify an optional widget that will wrap this text widget.
+  ///
+  /// For example, this is useful to add custom padding or decoration around the
+  /// text widget, but not on the overflow replacement widget.
+  final Widget Function(BuildContext context, Widget text)? wrapTextWidget;
+
   @override
   _AutoSizeTextState createState() => _AutoSizeTextState();
 }
@@ -270,7 +278,9 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       if (widget.overflowReplacement != null && !textFits) {
         return widget.overflowReplacement!;
       } else {
-        return text;
+        return widget.wrapTextWidget == null
+            ? text
+            : widget.wrapTextWidget!(context, text);
       }
     });
   }

--- a/test/wrap_text_widget.dart
+++ b/test/wrap_text_widget.dart
@@ -1,0 +1,36 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'utils.dart';
+
+void main() {
+  testWidgets('The text is not wrapped by a container', (tester) async {
+    await pump(
+      tester: tester,
+      widget: AutoSizeText(
+        'XXXXX',
+        style: TextStyle(fontSize: 20),
+      ),
+    );
+    var height = tester.getSize(find.byType(AutoSizeText)).height;
+    expect(height, 20);
+  });
+
+  testWidgets('The text is wrapped by a container with extra padding',
+      (tester) async {
+    await pump(
+      tester: tester,
+      widget: AutoSizeText(
+        'XXXXX',
+        style: TextStyle(fontSize: 20),
+        wrapTextWidget: (_, text) => Container(
+          padding: EdgeInsets.all(5),
+          child: text,
+        ),
+      ),
+    );
+    var height = tester.getSize(find.byType(AutoSizeText)).height;
+    expect(height, 30);
+  });
+}


### PR DESCRIPTION
This PR adds the ability to wrap the text by any other widget (like a `Container`), without wrapping the widget specified in the `overflowReplacement` parameter.

This is especially useful when you want to add extra padding on your text, but not on the overflow replacement widget.

For example:

```dart
AutoSizeText(
  'XXXXX', // Extra padding of 5px is added around this text
  style: TextStyle(fontSize: 20),
  wrapTextWidget: (_, text) => Container(
    padding: EdgeInsets.all(5),
    child: text,
  ),
  overflowReplacement: Text('*'), // No padding is added arount this replacement text
),
```