### PR TITLE
Removes reference to deprecated `addTime` method.

### DIFF
--- a/test/utils.dart
+++ b/test/utils.dart
@@ -45,7 +45,6 @@ Future prepareTests(WidgetTester tester) async {
     return;
   }
 
-  tester.binding.addTime(Duration(seconds: 10));
   prepared = true;
   final fontData = File('test/assets/Roboto-Regular.ttf')
       .readAsBytes()


### PR DESCRIPTION
This will unblock [flutter #129663](https://github.com/flutter/flutter/pull/129663) and allow the deprecation to complete.

Resolves #132 