### PR TITLE
Allow auto adjusting letterSpacing

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,7 +13,6 @@ linter:
   rules:
     - avoid_function_literals_in_foreach_calls
     - avoid_renaming_method_parameters
-    - avoid_returning_null
     - avoid_unused_constructor_parameters
     - await_only_futures
     - camel_case_types
@@ -25,13 +24,10 @@ linter:
     - empty_statements
     - implementation_imports
     - invariant_booleans
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - non_constant_identifier_names
     - only_throw_errors
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     - prefer_final_locals

--- a/demo/android/app/build.gradle
+++ b/demo/android/app/build.gradle
@@ -12,7 +12,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    namespace 'com.github.leisim.auto_size_text.demo'
+    compileSdk 34
 
     lintOptions {
         disable 'InvalidPackage'
@@ -20,8 +21,8 @@ android {
 
     defaultConfig {
         applicationId "com.github.leisim.auto_size_text.demo"
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName 'v1'
     }

--- a/demo/android/app/src/main/AndroidManifest.xml
+++ b/demo/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:icon="@drawable/ic_launcher">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"

--- a/demo/android/app/src/main/java/com/github/leisim/auto_size_text/demo/MainActivity.java
+++ b/demo/android/app/src/main/java/com/github/leisim/auto_size_text/demo/MainActivity.java
@@ -1,13 +1,14 @@
 package com.github.leisim.auto_size_text.demo;
 
 import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+
+import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+    GeneratedPluginRegistrant.registerWith(this.getFlutterEngine());
   }
 }

--- a/demo/android/build.gradle
+++ b/demo/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/demo/android/gradle.properties
+++ b/demo/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true

--- a/demo/android/gradle/wrapper/gradle-wrapper.properties
+++ b/demo/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -22,7 +22,7 @@ class App extends StatelessWidget {
       DeviceOrientation.landscapeRight,
     ]);
 
-    SystemChrome.setEnabledSystemUIOverlays([]);
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: []);
 
     return MaterialApp(
       theme: ThemeData.light(),
@@ -132,11 +132,6 @@ class _DemoAppState extends State<DemoApp> {
             icon: Icon(Icons.settings),
             title: Text('preset'),
             activeColor: colors[4],
-          ),
-          BottomNavyBarItem(
-            icon: Icon(MdiIcons.stackOverflow),
-            title: Text('replacement'),
-            activeColor: colors[5],
           ),
         ],
       ),

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -1,10 +1,10 @@
 name: demo
 description: AutoSizeText Demo App
 
-version: 1.0.0+2
+version: 1.0.0+3
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -13,11 +13,11 @@ dependencies:
   auto_size_text:
     path: ../
 
-  bottom_navy_bar: ^4.2.0
-  material_design_icons_flutter: ^4.0.5755
+  bottom_navy_bar: ^6.1.0
+  material_design_icons_flutter: ^7.0.7296
 
 dev_dependencies:
-  flutter_test: 
+  flutter_test:
     sdk: flutter
 
 flutter:

--- a/lib/auto_size_text.dart
+++ b/lib/auto_size_text.dart
@@ -3,6 +3,7 @@
 library auto_size_text;
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -11,7 +11,7 @@ class AutoSizeText extends StatefulWidget {
   ///
   /// If the [style] argument is null, the text will use the style from the
   /// closest enclosing [DefaultTextStyle].
-  const AutoSizeText(
+  AutoSizeText(
     String this.data, {
     Key? key,
     this.textKey,
@@ -36,7 +36,7 @@ class AutoSizeText extends StatefulWidget {
         super(key: key);
 
   /// Creates a [AutoSizeText] widget with a [TextSpan].
-  const AutoSizeText.rich(
+  AutoSizeText.rich(
     TextSpan this.textSpan, {
     Key? key,
     this.textKey,
@@ -184,7 +184,7 @@ class AutoSizeText extends StatefulWidget {
   /// This property also affects [minFontSize], [maxFontSize] and [presetFontSizes].
   ///
   /// The value given to the constructor as textScaleFactor. If null, will
-  /// use the [MediaQueryData.textScaleFactor] obtained from the ambient
+  /// use [TextScaler] obtained from the ambient
   /// [MediaQuery], or 1.0 if there is no [MediaQuery] in scope.
   final double? textScaleFactor;
 
@@ -314,8 +314,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       recognizer: widget.textSpan?.recognizer,
     );
 
-    final userScale =
-        widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context);
+    final userScale = widget.textScaleFactor ?? 1.0;
 
     int left;
     int right;
@@ -325,6 +324,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       final num defaultFontSize =
           style!.fontSize!.clamp(widget.minFontSize, widget.maxFontSize);
       final defaultScale = defaultFontSize * userScale / style.fontSize!;
+
       if (_checkTextFits(span, defaultScale, maxLines, size)) {
         return <Object>[defaultFontSize * userScale, true];
       }
@@ -379,7 +379,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         ),
         textAlign: widget.textAlign ?? TextAlign.left,
         textDirection: widget.textDirection ?? TextDirection.ltr,
-        textScaleFactor: scale,
+        textScaler: TextScaler.linear(scale),
         maxLines: words.length,
         locale: widget.locale,
         strutStyle: widget.strutStyle,
@@ -397,7 +397,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       text: text,
       textAlign: widget.textAlign ?? TextAlign.left,
       textDirection: widget.textDirection ?? TextDirection.ltr,
-      textScaleFactor: scale,
+      textScaler: TextScaler.linear(scale),
       maxLines: maxLines,
       locale: widget.locale,
       strutStyle: widget.strutStyle,
@@ -422,7 +422,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         locale: widget.locale,
         softWrap: widget.softWrap,
         overflow: widget.overflow,
-        textScaleFactor: 1,
+        textScaler: TextScaler.noScaling,
         maxLines: maxLines,
         semanticsLabel: widget.semanticsLabel,
       );
@@ -437,7 +437,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         locale: widget.locale,
         softWrap: widget.softWrap,
         overflow: widget.overflow,
-        textScaleFactor: fontSize / style.fontSize!,
+        textScaler: TextScaler.linear(fontSize / style.fontSize!),
         maxLines: maxLines,
         semanticsLabel: widget.semanticsLabel,
       );

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -11,7 +11,7 @@ class AutoSizeText extends StatefulWidget {
   ///
   /// If the [style] argument is null, the text will use the style from the
   /// closest enclosing [DefaultTextStyle].
-  AutoSizeText(
+  const AutoSizeText(
     String this.data, {
     Key? key,
     this.textKey,
@@ -36,7 +36,7 @@ class AutoSizeText extends StatefulWidget {
         super(key: key);
 
   /// Creates a [AutoSizeText] widget with a [TextSpan].
-  AutoSizeText.rich(
+  const AutoSizeText.rich(
     TextSpan this.textSpan, {
     Key? key,
     this.textKey,

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -31,6 +31,7 @@ class AutoSizeText extends StatefulWidget {
     this.overflowReplacement,
     this.textScaleFactor,
     this.maxLines,
+    this.minLetterSpacing,
     this.semanticsLabel,
   })  : textSpan = null,
         super(key: key);
@@ -56,6 +57,7 @@ class AutoSizeText extends StatefulWidget {
     this.overflowReplacement,
     this.textScaleFactor,
     this.maxLines,
+    this.minLetterSpacing,
     this.semanticsLabel,
   })  : data = null,
         super(key: key);
@@ -201,6 +203,17 @@ class AutoSizeText extends StatefulWidget {
   /// widget directly to entirely override the [DefaultTextStyle].
   final int? maxLines;
 
+  /// The minimum letter spacing constraint to be used when auto-sizing text.
+  ///
+  /// When specified, if the minimum font size is achieved and the text still
+  /// doesn't fit the available area, the letter spacing will be decreased until
+  /// the text fits or the [minLetterSpacing] value is achieved. It is decreased
+  /// by [stepGranularity] on each iteration.
+  final double? minLetterSpacing;
+
+  // The default letter spacing if none is specified.
+  static const double _defaultLetterSpacing = 0;
+
   /// An alternative semantics label for this text.
   ///
   /// If present, the semantics of this widget will contain this value instead
@@ -254,17 +267,20 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
       _validateProperties(style, maxLines);
 
-      final result = _calculateFontSize(size, style, maxLines);
+      final result =
+          _calculateFontSize(size, style, maxLines, widget.minLetterSpacing);
       final fontSize = result[0] as double;
       final textFits = result[1] as bool;
+      final letterSpacing = result[2] as double?;
 
       Widget text;
 
       if (widget.group != null) {
         widget.group!._updateFontSize(this, fontSize);
-        text = _buildText(widget.group!._fontSize, style, maxLines);
+        text =
+            _buildText(widget.group!._fontSize, letterSpacing, style, maxLines);
       } else {
-        text = _buildText(fontSize, style, maxLines);
+        text = _buildText(fontSize, letterSpacing, style, maxLines);
       }
 
       if (widget.overflowReplacement != null && !textFits) {
@@ -306,7 +322,11 @@ class _AutoSizeTextState extends State<AutoSizeText> {
   }
 
   List _calculateFontSize(
-      BoxConstraints size, TextStyle? style, int? maxLines) {
+    BoxConstraints size,
+    TextStyle? style,
+    int? maxLines,
+    double? minLetterSpacing,
+  ) {
     final span = TextSpan(
       style: widget.textSpan?.style ?? style,
       text: widget.textSpan?.text ?? widget.data,
@@ -315,6 +335,8 @@ class _AutoSizeTextState extends State<AutoSizeText> {
     );
 
     final userScale = widget.textScaleFactor ?? 1.0;
+
+    var letterSpacing = span.style!.letterSpacing;
 
     int left;
     int right;
@@ -326,7 +348,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       final defaultScale = defaultFontSize * userScale / style.fontSize!;
 
       if (_checkTextFits(span, defaultScale, maxLines, size)) {
-        return <Object>[defaultFontSize * userScale, true];
+        return <Object?>[defaultFontSize * userScale, true, letterSpacing];
       }
 
       left = (widget.minFontSize / widget.stepGranularity).floor();
@@ -337,9 +359,9 @@ class _AutoSizeTextState extends State<AutoSizeText> {
     }
 
     var lastValueFits = false;
+    var scale = userScale;
     while (left <= right) {
       final mid = (left + (right - left) / 2).floor();
-      double scale;
       if (presetFontSizes == null) {
         scale = mid * userScale * widget.stepGranularity / style!.fontSize!;
       } else {
@@ -355,6 +377,20 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
     if (!lastValueFits) {
       right += 1;
+      if (minLetterSpacing != null) {
+        letterSpacing = letterSpacing ?? AutoSizeText._defaultLetterSpacing;
+        do {
+          letterSpacing =
+              max(minLetterSpacing, letterSpacing! - widget.stepGranularity);
+          final stepSpan = TextSpan(
+            style: span.style!.copyWith(letterSpacing: letterSpacing),
+            text: span.text,
+            children: span.children,
+            recognizer: span.recognizer,
+          );
+          lastValueFits = _checkTextFits(stepSpan, scale, maxLines, size);
+        } while (!lastValueFits && letterSpacing > minLetterSpacing);
+      }
     }
 
     double fontSize;
@@ -364,7 +400,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       fontSize = presetFontSizes[right] * userScale;
     }
 
-    return <Object>[fontSize, lastValueFits];
+    return <Object?>[fontSize, lastValueFits, letterSpacing];
   }
 
   bool _checkTextFits(
@@ -410,12 +446,13 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         textPainter.width > constraints.maxWidth);
   }
 
-  Widget _buildText(double fontSize, TextStyle style, int? maxLines) {
+  Widget _buildText(
+      double fontSize, double? letterSpacing, TextStyle style, int? maxLines) {
     if (widget.data != null) {
       return Text(
         widget.data!,
         key: widget.textKey,
-        style: style.copyWith(fontSize: fontSize),
+        style: style.copyWith(fontSize: fontSize, letterSpacing: letterSpacing),
         strutStyle: widget.strutStyle,
         textAlign: widget.textAlign,
         textDirection: widget.textDirection,
@@ -430,7 +467,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       return Text.rich(
         widget.textSpan!,
         key: widget.textKey,
-        style: style,
+        style: style.copyWith(letterSpacing: letterSpacing),
         strutStyle: widget.strutStyle,
         textAlign: widget.textAlign,
         textDirection: widget.textDirection,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: auto_size_text
 description: Flutter widget that automatically resizes text to fit perfectly within its bounds.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/leisim/auto_size_text
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -13,4 +13,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: '>=1.11.1 <3.0.0'
+  lints: ^4.0.0

--- a/test/min_letter_spacing_test.dart
+++ b/test/min_letter_spacing_test.dart
@@ -1,0 +1,77 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'utils.dart';
+
+void main() {
+  testWidgets('Does not change letterSpacing if no minLetterSpacing is passed',
+      (tester) async {
+    await pumpAndExpectLetterSpacing(
+      tester: tester,
+      expectedLetterSpacing: null,
+      widget: SizedBox(
+        width: 100,
+        child: AutoSizeText(
+          'XXXXX',
+          style: TextStyle(fontSize: 60),
+          minFontSize: 60,
+          maxLines: 1,
+        ),
+      ),
+    );
+  });
+
+  testWidgets('Does not change letterSpacing if the text fits with minFontSize',
+      (tester) async {
+    await pumpAndExpectLetterSpacing(
+      tester: tester,
+      expectedLetterSpacing: null,
+      widget: SizedBox(
+        width: 100,
+        child: AutoSizeText(
+          'XXXXX',
+          style: TextStyle(fontSize: 60),
+          minFontSize: 20,
+          maxLines: 1,
+          minLetterSpacing: -60,
+        ),
+      ),
+    );
+  });
+
+  testWidgets('Respects minLetterSpacing', (tester) async {
+    await pumpAndExpectLetterSpacing(
+      tester: tester,
+      expectedLetterSpacing: -20,
+      widget: SizedBox(
+        width: 100,
+        child: AutoSizeText(
+          'XXXXX',
+          style: TextStyle(fontSize: 60),
+          minFontSize: 60,
+          maxLines: 1,
+          minLetterSpacing: -20,
+        ),
+      ),
+    );
+  });
+
+  testWidgets('letterSpacing is larger than minLetterSpacing if enough space',
+      (tester) async {
+    await pumpAndExpectLetterSpacing(
+      tester: tester,
+      expectedLetterSpacing: -40,
+      widget: SizedBox(
+        width: 100,
+        child: AutoSizeText(
+          'XXXXX',
+          style: TextStyle(fontSize: 60),
+          minFontSize: 60,
+          maxLines: 1,
+          minLetterSpacing: -60,
+        ),
+      ),
+    );
+  });
+}

--- a/test/min_max_font_size_test.dart
+++ b/test/min_max_font_size_test.dart
@@ -1,6 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'utils.dart';

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 double effectiveFontSize(Text text) =>
     (text.textScaleFactor ?? 1) * text.style!.fontSize!;
 
+double? effectiveLetterSpacing(Text text) => text.style!.letterSpacing;
+
 bool doesTextFit(
   Text text, [
   double maxWidth = double.infinity,
@@ -83,6 +85,15 @@ Future pumpAndExpectFontSize({
 }) async {
   final text = await pumpAndGetText(tester: tester, widget: widget);
   expect(effectiveFontSize(text), expectedFontSize);
+}
+
+Future pumpAndExpectLetterSpacing({
+  required WidgetTester tester,
+  required double? expectedLetterSpacing,
+  required Widget widget,
+}) async {
+  final text = await pumpAndGetText(tester: tester, widget: widget);
+  expect(effectiveLetterSpacing(text), expectedLetterSpacing);
 }
 
 RichText getRichText(WidgetTester tester) =>

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,12 +1,11 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 double effectiveFontSize(Text text) =>
-    (text.textScaleFactor ?? 1) * text.style!.fontSize!;
+    text.textScaler?.scale(text.style!.fontSize!) ?? text.style!.fontSize!;
 
 double? effectiveLetterSpacing(Text text) => text.style!.letterSpacing;
 
@@ -27,7 +26,7 @@ bool doesTextFit(
     text: span,
     textAlign: text.textAlign ?? TextAlign.start,
     textDirection: text.textDirection,
-    textScaleFactor: text.textScaleFactor ?? 1,
+    textScaler: text.textScaler ?? TextScaler.linear(1),
     maxLines: text.maxLines,
     locale: text.locale,
     strutStyle: text.strutStyle,


### PR DESCRIPTION
Implements #73.

The letter spacing resizing is done when it reaches the `MinFontSize` and the text still does not fit. There is no need to resize the letter spacing earlier since resizing the text size already reduces the space between each character.

I did not add a `maxLetterSpacing` since I did not find it relevant. You can set the max letter spacing in the starting text style.
