### PR TITLE
Fix Flutter 3.24 and later. Support textScaler in favor of the deprecated textScaleFactor. Upgrade the demo project and dependencies

### DIFF
--- a/demo/android/app/build.gradle
+++ b/demo/android/app/build.gradle
@@ -12,7 +12,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    namespace 'com.github.leisim.auto_size_text.demo'
+    compileSdk 34
 
     lintOptions {
         disable 'InvalidPackage'
@@ -20,8 +21,8 @@ android {
 
     defaultConfig {
         applicationId "com.github.leisim.auto_size_text.demo"
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName 'v1'
     }

--- a/demo/android/app/src/main/AndroidManifest.xml
+++ b/demo/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:icon="@drawable/ic_launcher">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"

--- a/demo/android/app/src/main/java/com/github/leisim/auto_size_text/demo/MainActivity.java
+++ b/demo/android/app/src/main/java/com/github/leisim/auto_size_text/demo/MainActivity.java
@@ -1,13 +1,14 @@
 package com.github.leisim.auto_size_text.demo;
 
 import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+
+import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
 public class MainActivity extends FlutterActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+    GeneratedPluginRegistrant.registerWith(this.getFlutterEngine());
   }
 }

--- a/demo/android/build.gradle
+++ b/demo/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/demo/android/gradle.properties
+++ b/demo/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true

--- a/demo/android/gradle/wrapper/gradle-wrapper.properties
+++ b/demo/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -22,7 +22,7 @@ class App extends StatelessWidget {
       DeviceOrientation.landscapeRight,
     ]);
 
-    SystemChrome.setEnabledSystemUIOverlays([]);
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: []);
 
     return MaterialApp(
       theme: ThemeData.light(),
@@ -132,11 +132,6 @@ class _DemoAppState extends State<DemoApp> {
             icon: Icon(Icons.settings),
             title: Text('preset'),
             activeColor: colors[4],
-          ),
-          BottomNavyBarItem(
-            icon: Icon(MdiIcons.stackOverflow),
-            title: Text('replacement'),
-            activeColor: colors[5],
           ),
         ],
       ),

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -1,10 +1,10 @@
 name: demo
 description: AutoSizeText Demo App
 
-version: 1.0.0+2
+version: 1.0.0+3
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -13,11 +13,11 @@ dependencies:
   auto_size_text:
     path: ../
 
-  bottom_navy_bar: ^4.2.0
-  material_design_icons_flutter: ^4.0.5755
+  bottom_navy_bar: ^6.1.0
+  material_design_icons_flutter: ^7.0.7296
 
 dev_dependencies:
-  flutter_test: 
+  flutter_test:
     sdk: flutter
 
 flutter:

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -11,7 +11,7 @@ class AutoSizeText extends StatefulWidget {
   ///
   /// If the [style] argument is null, the text will use the style from the
   /// closest enclosing [DefaultTextStyle].
-  const AutoSizeText(
+  AutoSizeText(
     String this.data, {
     Key? key,
     this.textKey,
@@ -36,7 +36,7 @@ class AutoSizeText extends StatefulWidget {
         super(key: key);
 
   /// Creates a [AutoSizeText] widget with a [TextSpan].
-  const AutoSizeText.rich(
+  AutoSizeText.rich(
     TextSpan this.textSpan, {
     Key? key,
     this.textKey,
@@ -184,7 +184,7 @@ class AutoSizeText extends StatefulWidget {
   /// This property also affects [minFontSize], [maxFontSize] and [presetFontSizes].
   ///
   /// The value given to the constructor as textScaleFactor. If null, will
-  /// use the [MediaQueryData.textScaleFactor] obtained from the ambient
+  /// use [TextScaler] obtained from the ambient
   /// [MediaQuery], or 1.0 if there is no [MediaQuery] in scope.
   final double? textScaleFactor;
 
@@ -314,8 +314,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       recognizer: widget.textSpan?.recognizer,
     );
 
-    final userScale =
-        widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context);
+    final userScale = widget.textScaleFactor ?? 1.0;
 
     int left;
     int right;
@@ -325,6 +324,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       final num defaultFontSize =
           style!.fontSize!.clamp(widget.minFontSize, widget.maxFontSize);
       final defaultScale = defaultFontSize * userScale / style.fontSize!;
+
       if (_checkTextFits(span, defaultScale, maxLines, size)) {
         return <Object>[defaultFontSize * userScale, true];
       }
@@ -379,7 +379,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         ),
         textAlign: widget.textAlign ?? TextAlign.left,
         textDirection: widget.textDirection ?? TextDirection.ltr,
-        textScaleFactor: scale,
+        textScaler: TextScaler.linear(scale),
         maxLines: words.length,
         locale: widget.locale,
         strutStyle: widget.strutStyle,
@@ -397,7 +397,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
       text: text,
       textAlign: widget.textAlign ?? TextAlign.left,
       textDirection: widget.textDirection ?? TextDirection.ltr,
-      textScaleFactor: scale,
+      textScaler: TextScaler.linear(scale),
       maxLines: maxLines,
       locale: widget.locale,
       strutStyle: widget.strutStyle,
@@ -422,7 +422,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         locale: widget.locale,
         softWrap: widget.softWrap,
         overflow: widget.overflow,
-        textScaleFactor: 1,
+        textScaler: TextScaler.noScaling,
         maxLines: maxLines,
         semanticsLabel: widget.semanticsLabel,
       );
@@ -437,7 +437,7 @@ class _AutoSizeTextState extends State<AutoSizeText> {
         locale: widget.locale,
         softWrap: widget.softWrap,
         overflow: widget.overflow,
-        textScaleFactor: fontSize / style.fontSize!,
+        textScaler: TextScaler.linear(fontSize / style.fontSize!),
         maxLines: maxLines,
         semanticsLabel: widget.semanticsLabel,
       );

--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -11,7 +11,7 @@ class AutoSizeText extends StatefulWidget {
   ///
   /// If the [style] argument is null, the text will use the style from the
   /// closest enclosing [DefaultTextStyle].
-  AutoSizeText(
+  const AutoSizeText(
     String this.data, {
     Key? key,
     this.textKey,
@@ -36,7 +36,7 @@ class AutoSizeText extends StatefulWidget {
         super(key: key);
 
   /// Creates a [AutoSizeText] widget with a [TextSpan].
-  AutoSizeText.rich(
+  const AutoSizeText.rich(
     TextSpan this.textSpan, {
     Key? key,
     this.textKey,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: auto_size_text
 description: Flutter widget that automatically resizes text to fit perfectly within its bounds.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/leisim/auto_size_text
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=3.2.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -13,4 +13,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: '>=1.11.1 <3.0.0'
+  lints: ^4.0.0


### PR DESCRIPTION
This is primarily to fix the issue described [here](https://github.com/flutter/flutter/issues/153460), which can cause crashes and failed rendering on Flutter 3.24.0 and later. I have tested this against Flutter 3.24.3 and went through each example on the Demo app, which appeared to function exactly as we would want.