### PR TITLE
Fix TextPainter leaking

### DIFF
--- a/lib/src/auto_size_text.dart
+++ b/lib/src/auto_size_text.dart
@@ -387,8 +387,12 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
       wordWrapTextPainter.layout(maxWidth: constraints.maxWidth);
 
-      if (wordWrapTextPainter.didExceedMaxLines ||
-          wordWrapTextPainter.width > constraints.maxWidth) {
+      final exceeds = wordWrapTextPainter.didExceedMaxLines ||
+          wordWrapTextPainter.width > constraints.maxWidth;
+
+      wordWrapTextPainter.dispose();
+
+      if (exceeds) {
         return false;
       }
     }
@@ -405,9 +409,13 @@ class _AutoSizeTextState extends State<AutoSizeText> {
 
     textPainter.layout(maxWidth: constraints.maxWidth);
 
-    return !(textPainter.didExceedMaxLines ||
+    final fits = !(textPainter.didExceedMaxLines ||
         textPainter.height > constraints.maxHeight ||
         textPainter.width > constraints.maxWidth);
+
+    textPainter.dispose();
+
+    return fits;
   }
 
   Widget _buildText(double fontSize, TextStyle style, int? maxLines) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,3 +14,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: '>=1.11.1 <3.0.0'
+
+  # Setting to any will let the SDK version define
+  # the most compatible version.
+  leak_tracker_flutter_testing: any

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,10 +1,14 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Only Text', (tester) async {
     await pump(
       tester: tester,

--- a/test/group_builder_test.dart
+++ b/test/group_builder_test.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
@@ -45,6 +46,9 @@ void _expectFontSizes(WidgetTester tester, double fontSize) {
 }
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Group sync', (tester) async {
     await tester.pumpWidget(testWidget(width1: 300, width2: 300));
 

--- a/test/group_test.dart
+++ b/test/group_test.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
@@ -59,6 +60,9 @@ void _expectFontSizes(WidgetTester tester, double fontSize) {
 }
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Group sync', (tester) async {
     await tester.pumpWidget(GroupTest());
 

--- a/test/maxlines_test.dart
+++ b/test/maxlines_test.dart
@@ -1,10 +1,14 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Respects maxlines', (tester) async {
     await pump(
       tester: tester,

--- a/test/min_max_font_size_test.dart
+++ b/test/min_max_font_size_test.dart
@@ -2,10 +2,14 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Forces valid min and max fontSize', (tester) async {
     await tester.pumpWidget(
       AutoSizeText(

--- a/test/overflow_replacement_test.dart
+++ b/test/overflow_replacement_test.dart
@@ -1,10 +1,14 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Overflow replacement visible on overflow', (tester) async {
     final text = await pumpAndGetText(
       tester: tester,

--- a/test/preset_font_sizes_test.dart
+++ b/test/preset_font_sizes_test.dart
@@ -1,10 +1,14 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Preset font sizes', (tester) async {
     await pumpAndExpectFontSize(
       tester: tester,

--- a/test/text_fits_test.dart
+++ b/test/text_fits_test.dart
@@ -1,10 +1,14 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Text fits width', (tester) async {
     await pumpAndExpectFontSize(
       tester: tester,

--- a/test/wrap_words_test.dart
+++ b/test/wrap_words_test.dart
@@ -1,10 +1,14 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 
 import 'utils.dart';
 
 void main() {
+  LeakTesting.settings = LeakTesting.settings.withIgnored(createdByTestHelpers: true);
+  LeakTesting.enable();
+
   testWidgets('Do not wrap words', (tester) async {
     await pumpAndExpectFontSize(
       tester: tester,


### PR DESCRIPTION
Dispose it when it is no longer in use.

Also add leak detection to all the unit tests to prevent regressions.

Fixes #150 